### PR TITLE
Move the connection closure to where we _know_ we won't be reusing it.

### DIFF
--- a/clouddriver-kubernetes/src/main/groovy/io/fabric8/kubernetes/client/utils/BackwardsCompatibilityInterceptor.java
+++ b/clouddriver-kubernetes/src/main/groovy/io/fabric8/kubernetes/client/utils/BackwardsCompatibilityInterceptor.java
@@ -124,12 +124,12 @@ public class BackwardsCompatibilityInterceptor implements Interceptor {
     Request request = chain.request();
     Response response = chain.proceed(request);
     if (!response.isSuccessful() && responseCodeToTransformations.keySet().contains(response.code())) {
-      response.close();
       String url = request.url().toString();
       Matcher matcher = getMatcher(url);
       ResourceKey key = getKey(matcher);
       ResourceKey target = responseCodeToTransformations.get(response.code()).get(key);
       if (target != null) {
+        response.close(); // At this point, we know we won't reuse or return the response; so close it to avoid a connection leak.
         String newUrl = new StringBuilder(url)
             .replace(matcher.start(API_VERSION), matcher.end(API_VERSION), target.version) // Order matters: We need to substitute right to left, so that former substitution don't affect the indexes of later.
             .replace(matcher.start(API_GROUP), matcher.end(API_GROUP), target.group)


### PR DESCRIPTION
This change fixes the [upstream tests](https://github.com/fabric8io/kubernetes-client/pull/1239). I have a good feeling that it will fix our run as well.

